### PR TITLE
fix: Remove redundant 'api' segment from questionnaire API endpoints

### DIFF
--- a/frontend/src/components/QuestionAnswers.tsx
+++ b/frontend/src/components/QuestionAnswers.tsx
@@ -22,7 +22,7 @@ export default function QuestionAnswers() {
         setIsLoading(true);
 
         // Fetch question from API
-        const questionResponse = await fetch(`${API_URL}/api/questionnaires/${questionId}`);
+        const questionResponse = await fetch(`${API_URL}/questionnaires/${questionId}`);
         if (!questionResponse.ok) {
           throw new Error("Failed to fetch question");
         }
@@ -30,7 +30,7 @@ export default function QuestionAnswers() {
         setQuestion(questionData);
 
         // Fetch answers from API
-        const answersResponse = await fetch(`${API_URL}/api/questionnaires/${questionId}/answers`);
+        const answersResponse = await fetch(`${API_URL}/questionnaires/${questionId}/answers`);
         if (!answersResponse.ok) {
           throw new Error("Failed to fetch answers");
         }
@@ -52,7 +52,7 @@ export default function QuestionAnswers() {
   const handleUpvoteAnswer = async (answerId: string) => {
     try {
       // Call the upvote API
-      const response = await fetch(`${API_URL}/api/questionnaires/${questionId}/answers/${answerId}/upvote`, {
+      const response = await fetch(`${API_URL}/questionnaires/${questionId}/answers/${answerId}/upvote`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -87,7 +87,7 @@ export default function QuestionAnswers() {
     try {
       setIsSubmitting(true);
 
-      const response = await fetch(`${API_URL}/api/questionnaires/${questionId}/answer`, {
+      const response = await fetch(`${API_URL}/questionnaires/${questionId}/answer`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/components/QuestionSection.tsx
+++ b/frontend/src/components/QuestionSection.tsx
@@ -122,7 +122,7 @@ export default function QuestionSection() {
     try {
       // Call the upvote API
       const response = await fetch(
-        `${API_URL}/api/questionnaires/${questionId}/upvote`,
+        `${API_URL}/questionnaires/${questionId}/upvote`,
         {
           method: "POST",
           headers: {
@@ -185,7 +185,7 @@ export default function QuestionSection() {
         : "CU",
     };
 
-    const response = await fetch(`${API_URL}/api/questionnaires`, {
+    const response = await fetch(`${API_URL}/questionnaires`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -225,7 +225,7 @@ export default function QuestionSection() {
 
       // Call the answer API to store the answer in the database
       const response = await fetch(
-        `${API_URL}/api/questionnaires/${currentQuestion._id}/answer`,
+        `${API_URL}/questionnaires/${currentQuestion._id}/answer`,
         {
           method: "POST",
           headers: {
@@ -258,7 +258,7 @@ export default function QuestionSection() {
     setIsLoading(true);
     try {
       const response = await fetch(
-        `${API_URL}/api/questionnaires?category_id=${activeCategory}&sort_by=${sortBy}`
+        `${API_URL}/questionnaires?category_id=${activeCategory}&sort_by=${sortBy}`
       );
       if (!response.ok) {
         throw new Error("Failed to fetch questions");
@@ -276,7 +276,7 @@ export default function QuestionSection() {
     e.preventDefault();
 
     try {
-      const response = await fetch(`${API_URL}/api/questionnaires/register`, {
+      const response = await fetch(`${API_URL}/questionnaires/register`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
fix: Remove redundant 'api' segment from questionnaire API endpoints